### PR TITLE
Accept and ignore mode argument to fs.mkdir

### DIFF
--- a/instance/mkdir.js
+++ b/instance/mkdir.js
@@ -1,7 +1,9 @@
 module.exports = mkdir
 
-function mkdir(path, cb){
+function mkdir(path, mode, cb){
   var fs = this
+
+  if (cb === undefined) cb = mode;
 
   this.entry.getDirectory(path, {create: true}, success, error);
 


### PR DESCRIPTION
node fs accepts an optional mode argument to mkdir:

http://nodejs.org/api/fs.html#fs_fs_mkdir_path_mode_callback

    fs.mkdir(path[, mode], callback)#

but web-fs doesn't, so code attempting to use it will try to execute the number as the callback (TypeError: number is not a function). This PR adds the optional mode argument to web-fs, for better compatibility with code written for node.js (the mode is ignored, doesn't seem to make much sense for the web filesystem APIs)