### PR TITLE
Added out-of-bounds position file writing to mirror node's native fs functionality

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var test = require('tape')
 
 test(function(t){
 
-  t.plan(10)
+  t.plan(11)
 
   getFs(function(fs){
 
@@ -72,6 +72,14 @@ test(function(t){
             t.equal(file, 'a string')
           })
         })
+      })
+    })
+
+    fs.write('test-write-out-of-bounds', 'a string is the thing', 0, 21, 5, function(err){
+      if(err) throw err
+      fs.readFile('test-write-out-of-bounds', 'utf8', function(err, file){
+        if(err) throw err
+        t.equal(file.length, 26)
       })
     })
 


### PR DESCRIPTION
In node's native fs, when we do something like this on a new file:
```javascript
fs.write("./my_test_file", buffer, 0, buffer.length, 5, function() {})
```
Assuming a buffer length of 10B, we get a 15B sized file with our buffer as the last 10.
(This is of course true to existing files to which we try to write to a position greater than the file size)

Because of FileWriter's behavior (specifically, when one seek()s a position greater than the file size, it sets the writer to the file's max size) this was not the same behavior in this polyfill.
This PR seeks fixes the issue.