### PR TITLE
Added fs.read functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ WebFS.prototype = {
   createReadStream: require('./instance/create-read-stream.js'),
   createWriteStream: require('./instance/create-write-stream.js'),
   mkdir: require('./instance/mkdir.js'),
+  read: require('./instance/read.js'),
   readFile: require('./instance/read-file.js'),
   readdir: require('./instance/readdir.js'),
   rename: require('./instance/rename.js'),

--- a/instance/read.js
+++ b/instance/read.js
@@ -1,0 +1,29 @@
+module.exports = read
+
+function read(path, buffer, offset, length, position, cb){
+  this.entry.getFile(path, {create: "true"}, success, error)
+
+  function success(fileEntry){
+    fileEntry.file(function (file) {
+      var reader = new FileReader()
+      reader.onloadend = function (evt) {
+        if (evt.target.readyState === FileReader.DONE) {
+          var result = Buffer.concat([
+            buffer.slice(0, offset), 
+            new Buffer(evt.target.result),
+            buffer.slice(length, buffer.length)
+          ])
+          cb(null, evt.target.result.byteLength, result)
+        } else {
+          cb("Failed to read file", null)
+        }
+      }
+      reader.readAsArrayBuffer(file.slice(position, position + length))
+    })
+  }
+
+  function error(err){
+    cb(err, null)
+  }
+
+}

--- a/instance/read.js
+++ b/instance/read.js
@@ -10,7 +10,7 @@ function read(path, buffer, offset, length, position, cb){
         if (evt.target.readyState === FileReader.DONE) {
           var result = Buffer.concat([
             buffer.slice(0, offset), 
-            new Buffer(evt.target.result),
+            new Buffer(new Uint8Array(evt.target.result)),
             buffer.slice(length, buffer.length)
           ])
           cb(null, evt.target.result.byteLength, result)

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var test = require('tape')
 
 test(function(t){
 
-  t.plan(10)
+  t.plan(13)
 
   getFs(function(fs){
 
@@ -20,6 +20,18 @@ test(function(t){
       })
     })
 
+    // 3 test
+    fs.writeFile('partial-read', 'a string is the thing', function(err){
+      if(err) throw err 
+      fs.read('partial-read', new Buffer(0), 0, 6, 9, function(err, read, buffer){
+        var rawData = buffer.toString()
+        t.equal(read, 6)
+        t.equal(rawData, 'is the')
+        fs.unlink('partial-read', function(err){
+          t.equal(err, null)
+        })  
+      })  
+    })  
 
     var buf = new Float32Array(1024 * 1024);
     for(var x = 0; x < buf.length; x++){


### PR DESCRIPTION
Should behave exactly like node's fs.read (including partial reads into buffer, offsets within given buffer, etc.)
If I missed anything, please let me know.
