### PR TITLE
Small polyfills (exists + ftruncate + open)

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ WebFS.prototype = {
   exists: require('./instance/exists.js'),
   ftruncate: require('./instance/truncate.js'),
   mkdir: require('./instance/mkdir.js'),
+  open: require('./instance/open.js'),
   readFile: require('./instance/read-file.js'),
   readdir: require('./instance/readdir.js'),
   rename: require('./instance/rename.js'),

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ WebFS.prototype = {
 
   createReadStream: require('./instance/create-read-stream.js'),
   createWriteStream: require('./instance/create-write-stream.js'),
+  exists: require('./instance/exists.js'),
   mkdir: require('./instance/mkdir.js'),
   readFile: require('./instance/read-file.js'),
   readdir: require('./instance/readdir.js'),

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ WebFS.prototype = {
   createReadStream: require('./instance/create-read-stream.js'),
   createWriteStream: require('./instance/create-write-stream.js'),
   exists: require('./instance/exists.js'),
+  ftruncate: require('./instance/truncate.js'),
   mkdir: require('./instance/mkdir.js'),
   readFile: require('./instance/read-file.js'),
   readdir: require('./instance/readdir.js'),

--- a/instance/exists.js
+++ b/instance/exists.js
@@ -1,0 +1,10 @@
+module.exports = exists
+
+function exists(path, cb){
+  var fs = this
+  fs.stat(path, function(err) {
+    if (err) return cb(false)
+    cb(true)
+  })
+}
+

--- a/instance/open.js
+++ b/instance/open.js
@@ -1,0 +1,5 @@
+module.exports = open
+
+function open(path, flags, cb){
+  cb(null, path)
+}

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var test = require('tape')
 
 test(function(t){
 
-  t.plan(10)
+  t.plan(11)
 
   getFs(function(fs){
 
@@ -84,6 +84,14 @@ test(function(t){
           if(err) throw err
           t.equal(file, 'shorter value')
         })
+      })
+    })
+
+    // 1 test
+    fs.writeFile('test-exists', 'a string is the thing', function(err){
+      if(err) throw err
+      fs.exists('test-exists', function(exists) {
+        t.equal(exists, true)
       })
     })
 


### PR DESCRIPTION
I've included polyfills for exists, ftruncate and open

Ftruncate just points to truncate (the only difference being that ftruncate deals with fd while truncate deals with paths... since we don't have file descriptors in the browser, they're identical).

I've included exists even though it's deprecated because there are still libraries that use it (random-access-file in my use case). My opinion is that as long as node's fs supports it, web-fs should support it too. I hope you agree.

Open, in a similar way to ftruncate, is just there as pure polyfill. All it does is return the path of the file (again, seeing as there are no file descriptors in the browser).