### PR TITLE
Fix for chrome extension root directory stat

### DIFF
--- a/instance/stat.js
+++ b/instance/stat.js
@@ -18,6 +18,7 @@ function stat(path, cb){
 }
 
 function getEntry(root, path, opts, success, error){
+  if (path === "." || path === "/" || path === "./") return success(root)
   root.getFile(path, opts, success, function(){
     root.getDirectory(path, opts, success, error)
   })


### PR DESCRIPTION
Inside a chrome extension, before this fix, if you fs.stated "." or "/", you'd get an error.
With this, you just get handed the root path.